### PR TITLE
docs(design): correct §17.2 HMAC fixture; record spike #1 finding

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -49,6 +49,7 @@ PRD section references are given as `(P §x.y)`.
 | 25 | Threat-model assumption made explicit (Appendix D): single-user host. `wezsesh keygen` exit path is unchanged; the assumption is now a documented precondition. | v2-P9 |
 | 26 | Unicode sort caveat made explicit (§13.10): alphabetical sort is byte-order over NFC-normalised UTF-8 — locale-naive. Locale-aware ordering deferred. | v2-R10 |
 | 27 | Config-vs-env precedence specified explicitly (§11.4) and documented as a single resolution table. | v2-R16 |
+| 28 | §17.2 HMAC round-trip fixture corrected: the prior placeholder `id` (`01JABCDEFGHIJKLMNPQRSTUVWXY`) was 27 chars and used Crockford-excluded glyphs (I, L, U), so §9.3.1's `#id == 26` check would silent-drop it before HMAC verify ran. Replaced with `01JABCDEFGHJKMNPQRSTVWXYZA` (26 chars, all-Crockford-valid); `expected_hmac` is now pinned to the openssl-computed value. Pure-Lua HMAC + canonical-JSON encoder were validated against this fixture and against openssl during the IPC integration spike. | spike-#1 (`docs/issues/1.md`) |
 
 ### §0.2 — Document map
 
@@ -3301,16 +3302,31 @@ diff'd. Any divergence fails the build. CI runs under `LC_ALL=C`.
 ```
 key_hex = "a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1"
 canonical_json (noop fixture, including v):
-    {"args":{},"hmac":"<computed>","id":"01JABCDEFGHIJKLMNPQRSTUVWXY",
+    {"args":{},"hmac":"<computed>","id":"01JABCDEFGHJKMNPQRSTVWXYZA",
      "op":"noop","reply_sock":"/tmp/x.sock","target_window_id":1,
      "ts":1700000000,"v":1}
-expected_hmac = <pre-computed via reference RFC-4231 tooling, committed>
+canonical_sans_hmac.sha256 = f23dc13717d2c992a06d216528f9a0fb62ffd0d2b896ddf66e5dd3931911f616
+expected_hmac              = 52d0003484acc868ce5762d065e2360f98b37b777009306b3cec8e7177dd14b5
 ```
 
 Both encoders MUST emit `expected_hmac` for the canonical sans-hmac
 form. Both directions tested:
 - Lua signs → Go verifies
 - Go signs → Lua verifies
+
+`expected_hmac` was computed via `openssl dgst -sha256 -mac HMAC -macopt
+hexkey:<key>` (an RFC-4231 reference) over the canonical sans-hmac
+bytes. Cross-validated by an independent Go (`crypto/hmac`) and
+pure-Lua HMAC implementation during spike #1; see `docs/issues/1.md`
+for the run-time byte-equality artefacts.
+
+> **Note on the `id` literal.** Earlier drafts of this section carried
+> `01JABCDEFGHIJKLMNPQRSTUVWXY`, which was 27 chars and used `I`, `L`,
+> `U` — all excluded from the Crockford-base32 alphabet. Either flaw
+> would have caused §9.3.1's `#payload.id == 26` check to silent-drop
+> the fixture before HMAC verify ever ran, defeating the round-trip
+> test. The replacement above is 26 chars and uses no Crockford-excluded
+> glyphs; `expected_hmac` was recomputed against the new bytes.
 
 ### §17.3 — Required tests by surface
 


### PR DESCRIPTION
## Summary

- Fix `docs/design.md` §17.2's HMAC round-trip fixture: the placeholder id `01JABCDEFGHIJKLMNPQRSTUVWXY` is 27 chars and uses Crockford-excluded glyphs (I, L, U). §9.3.1's `#payload.id == 26` check would silent-drop the fixture before HMAC verify ran, defeating the cross-impl round-trip test the section is trying to specify.
- Replace with a clean 26-char Crockford-valid id (`01JABCDEFGHJKMNPQRSTVWXYZA`), pin `canonical_sans_hmac.sha256` and `expected_hmac` to the openssl-computed values, and add a brief explanatory note + a §0.1 changelog row referencing the spike #1 findings doc (`docs/issues/1.md`, lives on the `spike/e2e-noop` branch).

## What was empirically validated

During issue #1's spike (binary + Lua plugin, both pure-Lua and `crypto/hmac` HMAC paths):

| Surface | Value |
|---|---|
| canonical sans-hmac (post-§4.1 encode) | `{"args":{},"id":"01JABCDEFGHJKMNPQRSTVWXYZA","op":"noop","reply_sock":"/tmp/x.sock","target_window_id":1,"ts":1700000000,"v":1}` |
| sha256 of those bytes | `f23dc13717d2c992a06d216528f9a0fb62ffd0d2b896ddf66e5dd3931911f616` |
| HMAC-SHA-256 (key = §17.2 fixture) | `52d0003484acc868ce5762d065e2360f98b37b777009306b3cec8e7177dd14b5` |

All three values match across Go (`internal/canonicaljson` + `crypto/hmac`), pure Lua (`canonical_json.lua` + `hmac.lua`), and `openssl dgst -sha256 -mac HMAC -macopt hexkey:<key>` — i.e., the fixture is now self-consistent and verifiable from any RFC-4231 reference tool.

## Scope

Doc-only. No code changes; no other sections touched. The spike code itself lives on `spike/e2e-noop` and is not part of this PR.

## Test plan

- [ ] Reviewer compares the new fixture's sans-hmac bytes / sha256 / HMAC against `openssl dgst -sha256 -mac HMAC -macopt hexkey:a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1` independently.
- [ ] Reviewer confirms changelog row #28 reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)